### PR TITLE
Catalogue Index moon config option

### DIFF
--- a/LunarConfig.csproj
+++ b/LunarConfig.csproj
@@ -74,8 +74,8 @@
 		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
         <PackageReference Include="LethalCompany.GameLibs.Steam" Version="*-*" PrivateAssets="all" />
 		<PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />
-		<PackageReference Include="TeamXiaolan.DawnLib" Version="0.9.2" PrivateAssets="all" Publicize="true" />
-		<PackageReference Include="TeamXiaolan.DawnLib.DuskMod" Version="0.9.2" PrivateAssets="all" Publicize="true" />
+		<PackageReference Include="TeamXiaolan.DawnLib" Version="0.9.14" PrivateAssets="all" Publicize="true" />
+		<PackageReference Include="TeamXiaolan.DawnLib.DuskMod" Version="0.9.14" PrivateAssets="all" Publicize="true" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">

--- a/Objects/Config/LunarCentral.cs
+++ b/Objects/Config/LunarCentral.cs
@@ -2665,7 +2665,8 @@ namespace LunarConfig.Objects.Config
                 }
 
                 // This needs to be done after the original pass, so that any changes to Is Hidden/Locked apply correctly
-                if(enabledMoonSettings.Contains("Catalogue Index")) {
+                if(enabledMoonSettings.Contains("Catalogue Index")) 
+                {
                     List<DawnMoonInfo> originalCatalogueIndex = MoonRegistrationHandler.MoonGroupAlgorithm.Group(LethalContent.Moons.Values, true).SelectMany(it => it.Moons).ToList();
                     Dictionary<DawnMoonInfo, int> newCatalogueIndex = [];
 

--- a/Objects/Config/LunarCentral.cs
+++ b/Objects/Config/LunarCentral.cs
@@ -460,6 +460,7 @@ namespace LunarConfig.Objects.Config
                 configMoons.AddField("Spawnable Scrap", "Disable this to disable configuring this property in moon config entries.", true);
                 configMoons.AddField("Possible Interiors", "Disable this to disable configuring this property in moon config entries.", true);
                 configMoons.AddField("Tags", "Disable this to disable configuring this property in moon config entries.", true);
+                configMoons.AddField("Catalogue Index", "Disable this to disable configuring this property in moon config entries.", true);
 
                 configMoons.AddField("Is Hidden? & Is Locked? Blacklist", "Add moons here that LunarConfig will ignore Is Hidden? and Is Locked? settings for, regardless of whether Configure Content is enabled.\nThis setting uses the Appropriate Aliases of moons!", "");
 
@@ -2661,6 +2662,27 @@ namespace LunarConfig.Objects.Config
                     {
                         MiniLogger.LogError($"LunarConfig encountered an issue while configuring {uuid}, please report this!\n{e}");
                     }
+                }
+
+                // This needs to be done after the original pass, so that any changes to Is Hidden/Locked apply correctly
+                if(enabledMoonSettings.Contains("Catalogue Index")) {
+                    List<DawnMoonInfo> originalCatalogueIndex = MoonRegistrationHandler.MoonGroupAlgorithm.Group(LethalContent.Moons.Values, true).SelectMany(it => it.Moons).ToList();
+                    Dictionary<DawnMoonInfo, int> newCatalogueIndex = [];
+
+                    foreach(var moon in LethalContent.Moons)
+                    {
+                        string uuid = UUIDify(moon.Key.ToString());
+                        string niceUUID = NiceifyDawnUUID(moon.Key.Key);
+                        DawnMoonInfo dawnMoon = moon.Value;
+                        LunarConfigEntry moonEntry = moonFile.AddEntry($"{niceUUID} - {uuid}");
+
+                        moonEntry.AddField("Catalogue Index", "Changes the order in the moon catalogue in the terminal. A higher value means first/higher in the list.", originalCatalogueIndex.IndexOf(dawnMoon));
+                        newCatalogueIndex[dawnMoon] = moonEntry.GetValue<int>("Catalogue Index");
+                    }
+
+                    MoonRegistrationHandler.MoonGroupAlgorithm.OrderingSteps = [
+                        new LunarConfigCustomMoonOrder(newCatalogueIndex)  
+                    ];
                 }
 
                 ClearOrphanedEntries(moonFile.file);

--- a/Objects/LunarConfigCustomMoonOrder.cs
+++ b/Objects/LunarConfigCustomMoonOrder.cs
@@ -1,0 +1,26 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using Dawn;
+
+namespace LunarConfig.Objects.Config
+{
+    public class LunarConfigCustomMoonOrder(Dictionary<DawnMoonInfo, int> newCatalogueIndex) : IMoonOrderingStep
+    {
+        public IOrderedEnumerable<DawnMoonInfo> ApplyInitial(IEnumerable<DawnMoonInfo> input, bool reverse = false)
+        {
+            return reverse
+                ? input.OrderBy(GetIndex)
+                : input.OrderByDescending(GetIndex);
+        }
+
+        public IOrderedEnumerable<DawnMoonInfo> ApplyNext(IOrderedEnumerable<DawnMoonInfo> input, bool reverse = false)
+        {
+            return reverse
+                ? input.ThenBy(GetIndex)
+                : input.ThenByDescending(GetIndex);
+        }
+
+        private int GetIndex(DawnMoonInfo moonInfo) => newCatalogueIndex[moonInfo];
+    }
+}


### PR DESCRIPTION
<img width="872" height="170" alt="image" src="https://github.com/user-attachments/assets/004f4f20-77ea-46fc-8617-4d684a268bc0" />

this commit also bumps the nuget reference of dawnlib from 0.9.2 to 0.9.14, as the moon ordering stuff had changed between those versions